### PR TITLE
Use git cli in sync subcommand, and make custom implementation optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Option to use `git` cli in `sync` subcommand. This is now the default (#27)
+
 ## [0.4.0] - 2025-03-01
 
 ### Added

--- a/src/cmd_args.rs
+++ b/src/cmd_args.rs
@@ -63,15 +63,15 @@ pub(crate) enum Commands {
     Sync {
         /// Remote name to sync.
         remote_name: Option<String>,
+        /// Use custom git implementation.
+        #[arg(short, long)]
+        use_libgit2: bool,
         /// Whether to use ssh-agent
         #[arg(long)]
         use_sshagent: bool,
         /// Manually specify ssh key
         #[arg(long)]
         ssh_key: Option<PathBuf>,
-        /// Use git command.
-        #[arg(short, long)]
-        use_cl: bool,
     },
 
     /// Check config files validity.

--- a/src/cmd_args.rs
+++ b/src/cmd_args.rs
@@ -69,6 +69,9 @@ pub(crate) enum Commands {
         /// Manually specify ssh key
         #[arg(long)]
         ssh_key: Option<PathBuf>,
+        /// Use git command.
+        #[arg(short, long)]
+        use_cl: bool,
     },
 
     /// Check config files validity.

--- a/src/cmd_args.rs
+++ b/src/cmd_args.rs
@@ -1,7 +1,7 @@
 //! CLI arguments
 
-use crate::path;
 use crate::PathBuf;
+use crate::path;
 use clap::Args;
 use clap::{Parser, Subcommand};
 use clap_verbosity_flag::Verbosity;

--- a/src/cmd_init.rs
+++ b/src/cmd_init.rs
@@ -2,11 +2,13 @@
 //! Initialize xdbm for the device.
 
 use crate::backups::Backups;
-use crate::storages::{Storages, STORAGESFILE};
+use crate::storages::{STORAGESFILE, Storages};
 use crate::{
-    add_and_commit, backups, full_status, get_devices, write_devices, Device, DEVICESFILE,
+    DEVICESFILE, Device, add_and_commit, backups,
+    devices::{get_devices, write_devices},
+    full_status,
 };
-use anyhow::{anyhow, Context, Ok, Result};
+use anyhow::{Context, Ok, Result, anyhow};
 use core::panic;
 use git2::{Cred, RemoteCallbacks, Repository};
 use inquire::Password;

--- a/src/cmd_sync.rs
+++ b/src/cmd_sync.rs
@@ -12,12 +12,12 @@ pub(crate) fn cmd_sync(
     remote_name: Option<String>,
     use_sshagent: bool,
     ssh_key: Option<PathBuf>,
-    use_cl: bool,
+    use_libgit2: bool,
 ) -> Result<()> {
-    if use_cl {
-        cmd_sync_cl(config_dir, remote_name, ssh_key)
-    } else {
+    if use_libgit2 {
         cmd_sync_custom(config_dir, remote_name, use_sshagent, ssh_key)
+    } else {
+        cmd_sync_cl(config_dir, remote_name, ssh_key)
     }
 }
 

--- a/src/cmd_sync.rs
+++ b/src/cmd_sync.rs
@@ -142,13 +142,13 @@ where
         })
         .transfer_progress(|progress| {
             if progress.received_objects() == progress.total_objects() {
-                print!(
+                eprint!(
                     "Resolving deltas {}/{}\r",
                     progress.indexed_deltas(),
                     progress.total_deltas()
                 );
             } else {
-                print!(
+                eprint!(
                     "Received {}/{} objects ({}) in {} bytes\r",
                     progress.received_objects(),
                     progress.total_objects(),
@@ -156,7 +156,7 @@ where
                     progress.received_bytes(),
                 );
             }
-            io::stdout().flush().unwrap();
+            io::stderr().flush().unwrap();
             true
         })
         .sideband_progress(|text| {
@@ -210,7 +210,7 @@ fn pull(
         .context("Failed to fetch (pull)")?;
     let stats = remote.stats();
     if stats.local_objects() > 0 {
-        println!(
+        eprintln!(
             "\rReceived {}/{} objects in {} bytes (used {} local objects)",
             stats.indexed_objects(),
             stats.total_objects(),
@@ -218,7 +218,7 @@ fn pull(
             stats.local_objects(),
         );
     } else {
-        println!(
+        eprintln!(
             "\rReceived {}/{} objects in {} bytes",
             stats.indexed_objects(),
             stats.total_objects(),
@@ -259,7 +259,7 @@ fn pull(
                 None => String::from_utf8_lossy(ref_remote.name_bytes()).to_string(),
             };
             let msg = format!("Fast-Forward: Setting {} to id: {}", name, fetch_head.id());
-            println!("{}", msg);
+            eprintln!("{}", msg);
             ref_remote
                 .set_target(fetch_head.id(), &msg)
                 .context("failed to set target")?;

--- a/src/cmd_sync.rs
+++ b/src/cmd_sync.rs
@@ -3,10 +3,24 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Context, Result};
-use git2::{build::CheckoutBuilder, Cred, FetchOptions, PushOptions, RemoteCallbacks, Repository};
+use anyhow::{Context, Result, anyhow};
+use git2::{Cred, FetchOptions, PushOptions, RemoteCallbacks, Repository, build::CheckoutBuilder};
 
 pub(crate) fn cmd_sync(
+    config_dir: &PathBuf,
+    remote_name: Option<String>,
+    use_sshagent: bool,
+    ssh_key: Option<PathBuf>,
+    use_cl: bool,
+) -> Result<()> {
+    if use_cl {
+        todo!("do here next")
+    } else {
+        cmd_sync_custom(config_dir, remote_name, use_sshagent, ssh_key)
+    }
+}
+
+fn cmd_sync_custom(
     config_dir: &PathBuf,
     remote_name: Option<String>,
     use_sshagent: bool,

--- a/src/cmd_sync.rs
+++ b/src/cmd_sync.rs
@@ -299,7 +299,7 @@ fn push(
     ssh_key: Option<&PathBuf>,
 ) -> Result<()> {
     debug!("push");
-    let callbacks = remote_callback(&use_sshagent, ssh_key);
+    let callbacks = remote_callback(use_sshagent, ssh_key);
     let mut push_options = PushOptions::new();
     push_options.remote_callbacks(callbacks);
     let num_push_refspecs = remote

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,8 @@ fn main() -> Result<()> {
             remote_name,
             use_sshagent,
             ssh_key,
-        } => cmd_sync::cmd_sync(&config_dir, remote_name, use_sshagent, ssh_key)?,
+            use_cl,
+        } => cmd_sync::cmd_sync(&config_dir, remote_name, use_sshagent, ssh_key, use_cl)?,
         Commands::Status {
             path,
             storage,

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use std::path::{self, PathBuf};
 use storages::Storages;
 
 use crate::cmd_args::{BackupSubCommands, Cli, Commands, StorageCommands};
-use devices::{Device, DEVICESFILE, *};
+use devices::{DEVICESFILE, Device};
 
 mod backups;
 mod cmd_args;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,10 +94,10 @@ fn main() -> Result<()> {
         }
         Commands::Sync {
             remote_name,
+            use_libgit2,
             use_sshagent,
             ssh_key,
-            use_cl,
-        } => cmd_sync::cmd_sync(&config_dir, remote_name, use_sshagent, ssh_key, use_cl)?,
+        } => cmd_sync::cmd_sync(&config_dir, remote_name, use_sshagent, ssh_key, use_libgit2)?,
         Commands::Status {
             path,
             storage,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -78,14 +78,14 @@ mod integrated_test {
             Command::cargo_bin("xdbm")?
                 .arg("-c")
                 .arg(config_dir)
-                .args(["sync", "-vvvv", "-u"])
+                .args(["sync", "-vvvv"])
                 .assert()
                 .success();
         } else {
             Command::cargo_bin("xdbm")?
                 .arg("-c")
                 .arg(config_dir)
-                .args(["sync", "-vvvv"])
+                .args(["sync", "-vvvv", "-u"])
                 .assert()
                 .success();
         }
@@ -338,6 +338,7 @@ mod integrated_test {
             .arg(config_dir_2.path())
             .arg("sync")
             .arg("-vvvv")
+            .arg("-u")
             .assert()
             .success()
             .stderr(predicate::str::contains("successfully pushed"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5,8 +5,8 @@ mod integrated_test {
         path,
     };
 
-    use anyhow::{anyhow, Context, Ok, Result};
-    use assert_cmd::{assert::OutputAssertExt, Command};
+    use anyhow::{Context, Ok, Result, anyhow};
+    use assert_cmd::{Command, assert::OutputAssertExt};
     use git2::Repository;
     use log::{debug, trace};
     use predicates::{boolean::PredicateBooleanExt, prelude::predicate};
@@ -73,13 +73,22 @@ mod integrated_test {
         Ok(())
     }
 
-    fn run_sync_cmd(config_dir: &path::Path) -> Result<()> {
-        Command::cargo_bin("xdbm")?
-            .arg("-c")
-            .arg(config_dir)
-            .args(["sync", "-vvvv"])
-            .assert()
-            .success();
+    fn run_sync_cmd(config_dir: &path::Path, use_cl: bool) -> Result<()> {
+        if use_cl {
+            Command::cargo_bin("xdbm")?
+                .arg("-c")
+                .arg(config_dir)
+                .args(["sync", "-vvvv", "-u"])
+                .assert()
+                .success();
+        } else {
+            Command::cargo_bin("xdbm")?
+                .arg("-c")
+                .arg(config_dir)
+                .args(["sync", "-vvvv"])
+                .assert()
+                .success();
+        }
         Ok(())
     }
 
@@ -391,8 +400,8 @@ mod integrated_test {
             std::fs::read_to_string(config_dir_1.join("storages.yml"))?.contains("parent: gdrive1")
         );
 
-        run_sync_cmd(&config_dir_1)?;
-        run_sync_cmd(&config_dir_2)?;
+        run_sync_cmd(&config_dir_1, false)?;
+        run_sync_cmd(&config_dir_2, false)?;
 
         // bind
         //
@@ -606,8 +615,8 @@ mod integrated_test {
                     .and(predicate::str::contains("foodoc").not()),
             );
 
-        run_sync_cmd(&config_dir_2)?;
-        run_sync_cmd(&config_dir_1)?;
+        run_sync_cmd(&config_dir_2, true)?;
+        run_sync_cmd(&config_dir_1, true)?;
 
         // bind
         //
@@ -722,8 +731,8 @@ mod integrated_test {
             .assert()
             .success();
 
-        run_sync_cmd(&config_dir_1)?;
-        run_sync_cmd(&config_dir_2)?;
+        run_sync_cmd(&config_dir_1, false)?;
+        run_sync_cmd(&config_dir_2, false)?;
 
         // backup add
         //


### PR DESCRIPTION
Resolves #24

- **new: add use_cl option and separate to function**
- **refactor: format**
- **new(sync): add option to use git cli**
- **change(sync)!: now it use git cli by default**
